### PR TITLE
Add emptyslice field tag

### DIFF
--- a/gen/encoder.go
+++ b/gen/encoder.go
@@ -53,13 +53,14 @@ var primitiveStringEncoders = map[reflect.Kind]string{
 type fieldTags struct {
 	name string
 
-	omit        bool
-	omitEmpty   bool
-	noOmitEmpty bool
-	asString    bool
-	required    bool
-	intern      bool
-	noCopy      bool
+	omit            bool
+	omitEmpty       bool
+	noOmitEmpty     bool
+	asString        bool
+	required        bool
+	intern          bool
+	noCopy          bool
+	nilSliceAsEmpty bool
 }
 
 // parseFieldTags parses the json field tag into a structure.
@@ -84,6 +85,8 @@ func parseFieldTags(f reflect.StructField) fieldTags {
 			ret.intern = true
 		case s == "nocopy":
 			ret.noCopy = true
+		case s == "emptyslice":
+			ret.nilSliceAsEmpty = true
 		}
 	}
 
@@ -152,7 +155,7 @@ func (g *Generator) genTypeEncoderNoCheck(t reflect.Type, in string, tags fieldT
 				fmt.Fprintln(g.out, ws+"out.Base64Bytes("+in+")")
 			}
 		} else {
-			if !assumeNonEmpty {
+			if !assumeNonEmpty && !tags.nilSliceAsEmpty {
 				fmt.Fprintln(g.out, ws+"if "+in+" == nil && (out.Flags & jwriter.NilSliceAsEmpty) == 0 {")
 				fmt.Fprintln(g.out, ws+`  out.RawString("null")`)
 				fmt.Fprintln(g.out, ws+"} else {")

--- a/tiny-tests/cosmwasm.go
+++ b/tiny-tests/cosmwasm.go
@@ -20,8 +20,8 @@ type ContractInfo struct {
 // another important struct that includes a slice of structs (which caused issues with another parser)
 type MessageInfo struct {
 	Signer string
-	// TODO: how to ensure empty funds -> [] not nil
-	Funds []Coin
+	// Note: added custom tag "emptyslice" to never encode to nil, but rather []
+	Funds []Coin `json:",emptyslice"`
 }
 
 type Coin struct {

--- a/tiny-tests/cosmwasm_test.go
+++ b/tiny-tests/cosmwasm_test.go
@@ -59,11 +59,7 @@ func TestInfoEncoding(t *testing.T) {
 		"empty": {
 			input:    `{}`,
 			expected: MessageInfo{},
-			// TODO: where to set this?
-			// desired behavior can be set by
-			// writer := &jwriter.Writer{Flags: jwriter.NilSliceAsEmpty}
-			// output: `{"signer":"","funds":[]}`,
-			output: `{"signer":"","funds":null}`,
+			output:   `{"signer":"","funds":[]}`,
 		},
 		"top fields": {
 			input: `{"signer":"cosmos1234","funds":[]}`,


### PR DESCRIPTION
Merge after #2

Add a new json tag, emptyslice that can be applied to any []Xyz field. If that field has length 0, rather than marshalling as null, it will marshal as []. This is more inline with what the Rust encoder expects.