### PR TITLE
Added some basic benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,13 @@ tiny-generate: build
 tiny-test: tiny-generate
 	# look into nounsafe later, this uses reflect, so I remove it just in case
 	go test -v -tags easyjson_nounsafe ./tiny-tests
+	cd benchmark && go test -benchmem -tags use_easyjson -bench .
 	@ golint -set_exit_status ./tiny-tests/*_easyjson.go
 	@ echo "No files should be listed below:"
 	@ grep -l encoding/json ./tiny-tests/*.go || true
+
+tiny-bench:
+	cd tiny-tests && go test -benchmem -bench .
 
 bench-other: generate
 	cd benchmark && make

--- a/tiny-tests/benchmark_test.go
+++ b/tiny-tests/benchmark_test.go
@@ -1,0 +1,25 @@
+package tinytest
+
+import (
+	"testing"
+)
+
+func BenchmarkStd_Unmarshal_Env(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var s Env
+		err := s.UnmarshalJSON(sampleEnvText)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}
+
+func BenchmarkStd_Unmarshal_Info(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var s MessageInfo
+		err := s.UnmarshalJSON(sampleMsgInfoText)
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}

--- a/tiny-tests/generate_test.go
+++ b/tiny-tests/generate_test.go
@@ -1,0 +1,34 @@
+package tinytest
+
+import (
+	"bytes"
+	"testing"
+)
+
+var sampleEnv = Env{
+	Contract: ContractInfo{Address: "wasm18vd8fpwxzck93qlwghaj6arh4p7c5n89k7fvsl"},
+	// Time in nanoseconds since epoch start
+	Block: BlockInfo{Height: 78000, Time: 1629131191823419000},
+}
+
+var sampleEnvText = []byte(`{"block":{"height":78000,"time":"1629131191823419000"},"contract":{"address":"wasm18vd8fpwxzck93qlwghaj6arh4p7c5n89k7fvsl"}}`)
+
+var sampleMsgInfo = MessageInfo{
+	Signer: "wasm18vd8fpwxzck93qlwghaj6arh4p7c5n89k7fvsl",
+	Funds:  []Coin{{Amount: "123000000", Denom: "utgd"}},
+}
+
+var sampleMsgInfoText = []byte(`{"signer":"wasm18vd8fpwxzck93qlwghaj6arh4p7c5n89k7fvsl","funds":[{"denom":"utgd","amount":"123000000"}]}`)
+
+func TestGenerateData(t *testing.T) {
+	bz, _ := sampleEnv.MarshalJSON()
+	// fmt.Println(string(bz))
+	if !bytes.Equal(bz, sampleEnvText) {
+		t.Fatal("Update sample text")
+	}
+	bz, _ = sampleMsgInfo.MarshalJSON()
+	// fmt.Println(string(bz))
+	if !bytes.Equal(bz, sampleMsgInfoText) {
+		t.Fatal("Update sample text")
+	}
+}


### PR DESCRIPTION
Merge after #3 

This adds `make tiny-bench` to give some results on the realistic structs we are dealing with. Unmarshal env and message info in around 300ns each, which seems quite fast (even if it is 10x slower in wasm, this is still a good enough for contracts)